### PR TITLE
Fix variable shadowing in delete confirmation

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -63,8 +63,8 @@ const Dashboard = ({ session }) => {
   };
 
   const handleDelete = async (id) => {
-    const confirm = window.confirm('Are you sure you want to delete this subscription?');
-    if (!confirm) return;
+    const userConfirmed = window.confirm('Are you sure you want to delete this subscription?');
+    if (!userConfirmed) return;
 
     const { error } = await supabase
       .from('subscriptions')


### PR DESCRIPTION
## Summary
- rename the variable that stores the confirmation result in Dashboard page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca28baab48332a07ef1b288f41702